### PR TITLE
Update @cpanel/api to allow yarn, but not require it

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
         "**/*.map.js",
         "documentation/**/*"
     ],
-    "engines": {
-        "yarn": "YARN NO LONGER USED - use npm instead."
-    },
     "scripts": {
         "build:prod": "npm run clean && npm run build:ts && npm run webpack:prod",
         "build:dev": "npm run clean && npm run build:ts-dev && npm run webpack:dev",


### PR DESCRIPTION
Case COBRA-12934: Blocking yarn causes problems for older versions
that were using the old verdaccio instance

Changelog: