### PR TITLE
Update @cpanel/api to allow yarn, but not require it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cpanel/api",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "cPanel API JavaScript and TypeScript interface libraries. This library provides a set of classes for calling cPanel WHM API 1 and UAPI calls. The classes hide much of the complexity of these APIs behind classes the abstract the underlying variances between these API systems. Users of this library can focus on what they want to accomplish rather the having to learn the various complexities of the underlying wire formats for each of the cPanel Products APIs",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -13,9 +13,6 @@
         "**/*.map.js",
         "documentation/**/*"
     ],
-    "engines": {
-        "yarn": "YARN NO LONGER USED - use npm instead."
-    },
     "scripts": {
         "build:prod": "npm run clean && npm run build:ts && npm run webpack:prod",
         "build:dev": "npm run clean && npm run build:ts-dev && npm run webpack:dev",


### PR DESCRIPTION
Case COBRA-12934: Blocking yarn causes problems for older versions
that were using the old verdaccio instance

Changelog: